### PR TITLE
Make progress bar work

### DIFF
--- a/src/RelevanceTrial.vue
+++ b/src/RelevanceTrial.vue
@@ -1,6 +1,6 @@
 <!-- RelevanceTrial.vue -->
 <template>
-  <Screen>
+  <Screen :progress="progress">
     <Slide>
       <Record
         :data="{
@@ -334,6 +334,10 @@ export default {
     group: {
       type: String,
       required: true
+    },
+    progress: {
+      type: Number,
+      default: undefined
     }
   },
   data() {


### PR DESCRIPTION
The `progress` prop is only defined on built-in Screen components.
RelevanceTrial is not a built-in Screen component.

```
<RelevanceTrial
        :key="i"
        :trial-n-r="i"
        :item="trial"
        :group="group"
        :progress="i / items.length"
      />
```

In order for the above to work, we'll need to define a progress prop on the RelevanceTrial component and pass the value to the Screen component used inside it.

I hope this clarifies why these changes work :)
